### PR TITLE
Fix a flaky test.

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -32,6 +32,8 @@ def test_masked(test_key, test_setting, is_sensitive, actual_value):
 
 
 def test_getitem(test_setting, test_key, actual_value):
+    with pytest.raises(KeyError):
+        test_setting[test_key]
     """ Ensure Sensitive objects return their underlying value """
     assert test_setting[test_key] == actual_value
 


### PR DESCRIPTION
# What is the purpose of the change
- This PR is to fix a flaky test `tests/test_settings.py::test_getitem[0-1]`, which can fail after running `tests/test_settings.py::test_delitem[0-1]`.

# Reproduce the test failure
- Run the following command:
```
python -m pytest tests/test_settings.py::test_delitem[0-1] tests/test_settings.py::test_getitem[0-1]
```
# Expected result
-  `tests/test_settings.py::test_getitem[0-1]` should pass after running `tests/test_settings.py::test_delitem[0-1]`.

# Actual result
```
self = <enpyronments.settings.Settings object at 0x7f5970754c40>, key = 'foo', extract_from_sensitive = True

    def __getitem__(self, key, extract_from_sensitive: bool = True):
        """ same as dict.__getitem__, but extracts the value of Sensitive type elements """
>       val = self.data.__getitem__(key)
E       KeyError: 'foo'

enpyronments/settings.py:42: KeyError

```

# Why it fails
- The key was deleted after running `tests/test_settings.py::test_delitem[0-1]`.

# Fix
- Reset the key-value before `tests/test_settings.py::test_getitem[0-1]`